### PR TITLE
Added specific steps for using and registering both Web API and SPA 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are two ways to run this sample:
 
 ## Using the demo environment
 
-This sample demonstrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clicking on the **Call Web API** button shows the Display name you used when you created your account. 
+This sample demonstrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clicking on the **Call Web API** button shows the display name you used when you created your account. 
 
 ### Step 1: Clone or download this repository
 
@@ -29,6 +29,8 @@ git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-msal-
 ```
 
 ### Step 2: Run the application
+
+Make sure you've [installed Node](https://nodejs.org/en/download/).
 
 From your shell or command line: 
 
@@ -44,7 +46,10 @@ The console window shows the port number for the web application
 Listening on port 6420...
 ```
 
-You can visit `http://localhost:6420` and click the **Login** button to start the Azure AD B2C sign in or sign up workflow.  
+You can visit `http://localhost:6420` and perform the following actions:
+1. Click the **Login** button to start the Azure AD B2C sign in or sign up workflow.  
+2. Once signed in, you can click the **Call Web API** button to have your display name returned from the Web API call as a JSON object. 
+3. Click **Logout** to logout from the application. 
 
 ## Using your own Azure AD B2C Tenant
 
@@ -52,11 +57,11 @@ In the previous section, you learned how to run the sample application using the
 
 ### Step 1: Get your own Azure AD B2C tenant
 
-First, you'll need to create an Azure AD B2C tenant by following [these instructions](https://azure.microsoft.com/documentation/articles/active-directory-b2c-get-started).
+First, you'll need an Azure AD B2C tenant. If you don't have an existing Azure AD B2C tenant that you can use for testing purposes, you can create your own by following [these instructions](https://azure.microsoft.com/documentation/articles/active-directory-b2c-get-started).
 
 ### Step 2: Create your own policies
 
-This sample uses two types of policies: a unified sign-up/sign-in policy & a profile editing policy.  Create one policy of each type by following [the instructions here](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
+This sample uses a unified sign-up/sign-in policy.  You can create [your own unified sign-up/sign-in policy](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
 
 If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those policies in this sample.  
 
@@ -64,42 +69,46 @@ If you already have existing policies in your Azure AD B2C tenant, feel free to 
 
 As you saw in the demo environment, this sample calls a Web API at https://fabrikamb2chello.azurewebsites.net. This demo Web API uses the same code found in the sample [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi), in case you need to reference it for debugging purposes. 
 
-You must replace the demo environment Web API with your own Web API. If you do not have your own Web API, you can clone the [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi) sample and register it within your tenant. 
+You must replace the demo environment Web API with your own Web API. If you do not have your own Web API, you can clone the [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi) sample and register it with your tenant. 
 
 #### How to setup and register the Node.js Web API sample
 
-First, clone the Node.js Web API sample repository into its own directory outside of this single page application cloned location, for example:  
+First, clone the Node.js Web API sample repository into its own directory, for example:  
 
 ```
 cd ..
 git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi.git
 ```
 
-which results in two folders `active-directory-b2c-javascript-nodejs-webapi` and `active-directory-b2c-javascript-msal-singlepageapp` side by side. 
+so the two folders `active-directory-b2c-javascript-nodejs-webapi` and `active-directory-b2c-javascript-msal-singlepageapp` are located side by side. 
 
-Second, follow the instructions at [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) to register the Node.js Web API sample within your tenant. Registering your Web API allows you to define the scopes that your single page application will request access tokens for. 
+Second, follow the instructions at [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) to register the Node.js Web API sample with your tenant. Registering your Web API allows you to define the scopes that your single page application will request access tokens for. 
 
 Provide the following values for the Node.js Web API registration: 
 
-- Provide a descriptive Name for the Node.js Web API. You will identify this application by its Name whenever working in the Azure portal.
-- Enable the **Web App/Web API** setting for your application.
+- Provide a descriptive Name for the Node.js Web API, for example, `My Test Node.js Web API`. You will identify this application by its Name whenever working in the Azure portal.
+- Mark **Yes** for the **Web App/Web API** setting for your application.
 - Set the **Reply URL** to `http://localhost:5000`. This is the port number that the Node.js Web API sample is configured to run on. 
-- Set the **AppID URI** to `hello`. The AppID URI is used to construct the scopes that are configured in you single page application's code. For example, in this Node.js Web API sample, the scope will have the value `https://<your-tenant-name>.onmicrosoft.com/hello/demo.read` 
-- Create the application. Once the application is created, open the applications **Published Scopes** window (in the left nav menu) and add the scope `demo.read` followed by a description `demoing a read scenario`.
+- Set the **AppID URI** to `hello`. This AppID URI is a unique identifier representing this Node.jS Web API. The AppID URI is used to construct the scopes that are configured in you single page application's code. For example, in this Node.js Web API sample, the scope will have the value `https://<your-tenant-name>.onmicrosoft.com/hello/demo.read` 
+- Create the application. 
+- Once the application is created, open your `My Test Node.js Web API` application and then open the **Published Scopes** window (in the left nav menu) and add the scope `demo.read` followed by a description `demoing a read scenario`. Click **Save**.
 
-Third, in the `index.html` file, update the following variables to refer to your Web API registration.  
+Third, in the `index.html` file of the Node.js Web API sample, update the following variables to refer to your Web API registration.  
 
 ```
 var tenantID = "<your-tenant-name>.onmicrosoft.com";
-var clientID = "<Application ID for your Node.js Web API>";
+var clientID = "<Application ID for your Node.js Web API - found on Properties page in Azure portal>";
 var policyName = "<Name of your sign in / sign up policy, e.g. B2C_1_SiUpIn>";
 ```
 
 Lastly, to run your Node.js Web API, run the following command from your shell or command line
 
 ```
+npm install && npm update
 node index.js
 ```
+
+Your Node.js Web API sample is now running on Port 5000. 
 
 ### Step 4: Register your own Web Application with Azure AD B2C
 
@@ -107,20 +116,23 @@ Next, you need to [register your single page application in your B2C tenant](htt
 
 Provide the following values for the Single Page Application registration: 
 
-- Provide a descriptive Name for the single page application. You will identify this application by its Name whenever working in the Azure portal.
-- Enable the **Web App/Web API** setting for your application.
+- Provide a descriptive Name for the single page application, for example, `My Test SPA`. You will identify this application by its Name whenever working in the Azure portal.
+- Mark **Yes** for the **Web App/Web API** setting for your application.
 - Set the **Reply URL** for your app to `http://localhost:6420`. This sample provided in this repository is configured to run on port 6420.
-- Create the application. Once the application is created, open the **API Access** window (in the left nav menu). Click **Add** and select the name of the Node.js Web API you registered previously. Select the scope(s) you defined previously, for example, `demo.read` and hit **Save**.
+- Create the application. 
+- Once the application is created, open your `My Test SPA` and open the **API Access** window (in the left nav menu). Click **Add** and select the name of the Node.js Web API you registered previously, `My Test Node.js Web API`. Select the scope(s) you defined previously, for example, `demo.read` and hit **Save**.
 
 ### Step 5: Configure the sample code to use your Azure AD B2C tenant
 
-Now you can replace the single page application's demo environment configuration with your own tenant.  
+Now in the sample code, you can replace the single page application's demo environment configuration with your own tenant.  
 
 1. Open the `index.html` file.
-1. Find the assignment for `ClientID` and replace the value with the Application ID for the single page application you registered in Step 4. 
-1. Find the assignment for `authority` and replacing `b2c_1_susi` with the name of the policy you created in Step 2, and `fabrikamb2c.onmicrosoft.com` by the name of your Azure AD B2C tenant.
+1. Find the assignment for `ClientID` and replace the value with the Application ID for the single page application you registered in Step 4, for example the Application ID found in `My Test SPA` application in the Azure portal. 
+1. Find the assignment for `authority` and replacing `b2c_1_susi` with the name of the policy you created in Step 2, and `fabrikamb2c.onmicrosoft.com` by the name of your Azure AD B2C tenant, for example `https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>`
 1. Find the assignment for the scopes `b2cScopes` replacing the URL by the scope URL you created for the Web API, e.g. `b2cScopes: ["https://<your-tenant-name>.onmicrosoft.com/hello/demo.read"]`
 2. Find the assignment for API URL `webApi` replacing the current URL by the URL where you deployed your Web API in Step 4, e.g. `webApi: 'http://localhost:5000/hello'`
+
+Your resulting code should look as follows:
 
 ```javascript
 <script class="pre">
@@ -136,21 +148,19 @@ Now you can replace the single page application's demo environment configuration
 
 ### Step 7: Run the sample
 
-1. Make sure you've [installed Node](https://nodejs.org/en/download/).
-1. Install the node dependencies:        
+1. Install the node dependencies if this is your first time running the app (e.g. if you skipped running in the demo environment):        
     ```
     cd active-directory-b2c-javascript-msal-singlepageapp
-    npm install
-    npm update
+    npm install && npm update
     ```       
-1. Run the Web application       
+2. Run the Web application       
     ```
     node server.js
     ```      
-1. With your favorite browser, navigate to `http://localhost:6420`.
-1. Click the **login** button at the top of the application screen. The sample works exactly in the same way regardless of the account type you choose, apart from some visual differences in the authentication and consent experience. Upon successful sign in, the application screen will show buttons that allow you to call an API and sign out.
-1. Click on the **Call Web API** and see the textual representation of the JSON object which is returned
-1. Sign out by clicking the **Logout** button.  
+3. Go to `http://localhost:6420`.
+4. Click the **login** button at the top of the application screen. The sample works exactly in the same way regardless of the account type you choose, apart from some visual differences in the authentication and consent experience. Upon successful sign in, the application screen will show buttons that allow you to call an API and sign out.
+5. Click on the **Call Web API** and see the textual representation of the JSON object that is returned. Make sure your Node.js Web API sample is still running on port 5000. 
+6. Sign out by clicking the **Logout** button.  
 
 ## More information
 For more information on Azure B2C, see [the Azure AD B2C documentation homepage](http://aka.ms/aadb2c). 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ There are two ways to run this sample:
 
 ## Using the demo environment
 
-This sample demostrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clikcing on the **Call Web API** button shows the Display name you used when you created your account. 
+This sample demostrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clicking on the **Call Web API** button shows the Display name you used when you created your account. 
 
 ### Step 1: Clone or download this repository
 
 From your shell or command line:
 
-```powershell
+```
 git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-msal-singlepageapp.git
 ```
 
@@ -51,60 +51,84 @@ Now that you have a good idea what this sample application does, it's time to co
 
 ### Step 1: Get your own Azure AD B2C tenant
 
-You can also modify the sample to use your own Azure AD B2C tenant.  First, you'll need to create an Azure AD B2C tenant by following [these instructions](https://azure.microsoft.com/documentation/articles/active-directory-b2c-get-started).
+First, you'll need to create an Azure AD B2C tenant by following [these instructions](https://azure.microsoft.com/documentation/articles/active-directory-b2c-get-started).
 
 ### Step 2: Create your own policies
 
-This sample uses three types of policies: a unified sign-up/sign-in policy & a profile editing policy.  Create one policy of each type by following [the instructions here](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
+This sample uses two types of policies: a unified sign-up/sign-in policy & a profile editing policy.  Create one policy of each type by following [the instructions here](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
 
-If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those policies.  
+If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those policies in this sample.  
 
-### Step 3: Register your own Web API
+### Step 3: Register your own Web API with Azure AD B2C
 
-As you saw in the demo environment, this sample calls a Web API at https://fabrikamb2chello.azurewebsites.net which has the same code as the sample [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi). You'll need to replace the demo environment Web API with your own Web API.
+As you saw in the demo environment, this sample calls a Web API at https://fabrikamb2chello.azurewebsites.net. This demo Web API uses the same code found in the sample [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi), in case you need to reference it for debugging purposes. 
 
-If you do not have your own Web API, you can use the 
+You must replace the demo environment Web API with your own Web API. If you do not have your own Web API, you can clone the [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi) sample and register it within your tenant. 
 
-you'll need to [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) so that you can define the scopes that your single page application will request access tokens for. 
+#### How to setup and register the Node.js Web API sample
 
+First, clone the Node.js Web API sample repository into its own directory outside of this single page application cloned location, for example:  
 
-Your web API registration should include the following information:
+```
+cd ..
+git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi.git
+```
 
+which results in two folders `active-directory-b2c-javascript-nodejs-webapi` and `active-directory-b2c-javascript-msal-singlepageapp` side by side. 
+
+Second, follow the instructions at [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) to register the Node.js Web API sample within your tenant. Registering your Web API allows you to define the scopes that your single page application will request access tokens for. 
+
+Provide the following values for the Node.js Web API registration: 
+
+- Provide a descriptive Name for the Node.js Web API. You will identify this application by its Name whenever working in the Azure portal.
 - Enable the **Web App/Web API** setting for your application.
-- Set the **Reply URL** to the appropriate value indicated in the sample or provide any URL if you're only doing the web api registration, for example `https://myapi`.
-- Make sure you also provide a **AppID URI**, for example `demoapi`, this is used to construct the scopes that are configured in you single page application's code.
-- (Optional) Once you're app is created, open the app's **Published Scopes** blade and add any extra scopes you want.
-- Copy the **AppID URI** and **Published Scopes values**, so you can input them in your application's code.
+- Set the **Reply URL** to `http://localhost:5000`. This is the port number that the Node.js Web API sample is configured to run on. 
+- Set the **AppID URI** to `hello`. The AppID URI is used to construct the scopes that are configured in you single page application's code. For example, in this Node.js Web API sample, the scope will have the value `https://<your-tenant-name>.onmicrosoft.com/hello/demo.read` 
+- Create the application. Once the application is created, open the applications **Published Scopes** window (in the left nav menu) and add the scope `demo.read` followed by a description `demoing a read scenario`.
 
-### [OPTIONAL] Step 5: Create your own application
+Third, in the `index.html` file, update the following variables to refer to your Web API registration.  
 
-Now you need to [register your single page application in your B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-application), so that it has its own Application ID. Don't forget to grant your application API Access to the web API you registered in the previous step.
+```
+var tenantID = "<your-tenant-name>.onmicrosoft.com";
+var clientID = "<Application ID for your Node.js Web API>";
+var policyName = "<Name of your sign in / sign up policy, e.g. B2C_1_SiUpIn>";
+```
 
-Your single page application registration should include the following information:
+Lastly, to run your Node.js Web API, run the following command from your shell or command line
 
+```
+node index.js
+```
+
+### Step 4: Register your own Web Application with Azure AD B2C
+
+Next, you need to [register your single page application in your B2C tenant](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-application). 
+
+Provide the following values for the Single Page Application registration: 
+
+- Provide a descriptive Name for the single page application. You will identify this application by its Name whenever working in the Azure portal.
 - Enable the **Web App/Web API** setting for your application.
-- Set the **Reply URL** for your app to `http://localhost:6420`
-- Once your app is created, open the app's **API access** blade and **Add** the API you created in the previous step.
-- Copy the Application ID generated for your application, so you can use it in the next step.
+- Set the **Reply URL** for your app to `http://localhost:6420`. This sample provided in this repository is configured to run on port 6420.
+- Create the application. Once the application is created, open the **API Access** window (in the left nav menu). Click **Add** and select the name of the Node.js Web API you registered previously. Select the scope(s) you defined previously, for example, `demo.read` and hit **Save**.
 
-### [OPTIONAL] Step 6: Configure the sample to use your Azure AD B2C tenant
+### Step 5: Configure the sample code to use your Azure AD B2C tenant
 
-Now you can replace the app's default configuration with your own.  
+Now you can replace the single page application's demo environment configuration with your own tenant.  
 
 1. Open the `index.html` file.
-1. Find the assignment for `ClientID` and replace the value with the Application ID from Step 5.
-1. Find the assignment for `authority` and replacing `b2c_1_susi`by the name of the policy you created in Step 3, and `fabrikamb2c.onmicrosoft.com` by the name of the Azure AD B2C tenant.
-1. Find the assignment for the scopes `b2cScopes` replacing the URL by the scope URL you created for the Web API, as provided in the B2C application registration portal
-1. Find the assignment for API URL `webApi` replacing the current URL by the URL where you deployed your Web API in Step 4.
+1. Find the assignment for `ClientID` and replace the value with the Application ID for the single page application you registered in Step 4. 
+1. Find the assignment for `authority` and replacing `b2c_1_susi` with the name of the policy you created in Step 2, and `fabrikamb2c.onmicrosoft.com` by the name of your Azure AD B2C tenant.
+1. Find the assignment for the scopes `b2cScopes` replacing the URL by the scope URL you created for the Web API, e.g. `b2cScopes: ["https://<your-tenant-name>.onmicrosoft.com/hello/demo.read"]`
+2. Find the assignment for API URL `webApi` replacing the current URL by the URL where you deployed your Web API in Step 4, e.g. `webApi: 'http://localhost:5000/hello'`
 
 ```javascript
 <script class="pre">
   // The current application coordinates were pre-registered in a B2C tenant.
   var applicationConfig = {
-    clientID: 'e760cab2-b9a1-4c0d-86fb-ff7084abd902',
-    authority: "https://login.microsoftonline.com/tfp/fabrikamb2c.onmicrosoft.com/b2c_1_susi",
-    b2cScopes: ["https://fabrikamb2c.onmicrosoft.com/demoapi/demo.read"],
-    webApi: 'https://fabrikamb2chello.azurewebsites.net/hello',
+    clientID: '<Application ID for your single page application>',
+    authority: "https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>",
+    b2cScopes: ["https://<your-tenant-name>.onmicrosoft.com/hello/demo.read"],
+    webApi: 'http://localhost:5000/hello',
   };
 </script>
 ```
@@ -113,18 +137,18 @@ Now you can replace the app's default configuration with your own.
 
 1. Make sure you've [installed Node](https://nodejs.org/en/download/).
 1. Install the node dependencies:        
-    ```powershell
+    ```
     cd active-directory-b2c-javascript-msal-singlepageapp
     npm install
     npm update
     ```       
 1. Run the Web application       
-    ```powershell
+    ```
     node server.js
     ```      
 1. With your favorite browser, navigate to `http://localhost:6420`.
 1. Click the **login** button at the top of the application screen. The sample works exactly in the same way regardless of the account type you choose, apart from some visual differences in the authentication and consent experience. Upon successful sign in, the application screen will show buttons that allow you to call an API and sign out.
-1. Click on the **Call Web API** and see the textual representation of the JSon object which is returned
+1. Click on the **Call Web API** and see the textual representation of the JSON object which is returned
 1. Sign out by clicking the **Logout** button.  
 
 ## More information

--- a/README.md
+++ b/README.md
@@ -6,21 +6,44 @@ author: jmprieur
 
 # Single-Page Application built on MSAL.js with Azure AD B2C
 
-> **IMPORTANT NOTE: Silent renewing of access tokens is not supported by all social identity providers.**
+:warning: Silent renewing of access tokens is not supported by all social identity providers.
 
 This simple sample demonstrates how to use the [Microsoft Authentication Library Preview for JavaScript (msal.js)](https://github.com/AzureAD/microsoft-authentication-library-for-js) to get an access token and call an API secured by Azure AD B2C.
 
 ## How To Run This Sample
 
-The sample is already configured to use a demo environment and can be run simply by downloading the code and running the app on your machine. Follow the instructions below if you would like to use your own Azure AD B2C configuration.
+There are two ways to run this sample:
+1. **Using the demo environment** - The sample is already configured to use a demo environment and can be run simply by downloading this repository and running the app on your machine. See steps below for Running with demo environment.
+2. **Using your own Azure AD B2C tenant** - If you would like to use your own Azure AD B2C configuration, follow the steps listed below for Using your own Azure AD B2C tenant.
 
-### Step 1:  Clone or download this repository
+### Using the demo environment
+
+This sample demostrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clikcing on the **Call Web API** button shows the Display name you used when you created your account. 
+
+#### Step 1: Clone or download this repository
 
 From your shell or command line:
 
 ```powershell
 git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-msal-singlepageapp.git
 ```
+
+#### Step 2: Run the application
+
+From your shell or command line: 
+
+```
+cd active-directory-b2c-javascript-msal-singlepageapp
+node server.js
+```
+
+The console window shows the port number for the web application
+
+```
+Listening on port 6420...
+```
+
+You can visit `http://localhost:6420` and click the **Login** button to start the Azure AD B2C sign in or sign up workflow.  
 
 ### [OPTIONAL] Step 2: Get your own Azure AD B2C tenant
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ There are two ways to run this sample:
 1. **Using the demo environment** - The sample is already configured to use a demo environment and can be run simply by downloading this repository and running the app on your machine. See steps below for Running with demo environment.
 2. **Using your own Azure AD B2C tenant** - If you would like to use your own Azure AD B2C configuration, follow the steps listed below for Using your own Azure AD B2C tenant.
 
-### Using the demo environment
+## Using the demo environment
 
 This sample demostrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clikcing on the **Call Web API** button shows the Display name you used when you created your account. 
 
-#### Step 1: Clone or download this repository
+### Step 1: Clone or download this repository
 
 From your shell or command line:
 
@@ -28,7 +28,7 @@ From your shell or command line:
 git clone https://github.com/Azure-Samples/active-directory-b2c-javascript-msal-singlepageapp.git
 ```
 
-#### Step 2: Run the application
+### Step 2: Run the application
 
 From your shell or command line: 
 
@@ -45,21 +45,28 @@ Listening on port 6420...
 
 You can visit `http://localhost:6420` and click the **Login** button to start the Azure AD B2C sign in or sign up workflow.  
 
-### [OPTIONAL] Step 2: Get your own Azure AD B2C tenant
+## Using the Azure AD B2C Tenant
+
+Now that you have a good idea what this sample application does, it's time to configure the sample to use your own Azure AD B2C tenant. 
+
+### Step 1: Get your own Azure AD B2C tenant
 
 You can also modify the sample to use your own Azure AD B2C tenant.  First, you'll need to create an Azure AD B2C tenant by following [these instructions](https://azure.microsoft.com/documentation/articles/active-directory-b2c-get-started).
 
-> *IMPORTANT*: if you choose to perform one of the optional steps, you have to perform ALL of them for the sample to work as expected.
-
-### [OPTIONAL] Step 3: Create your own policies
+### Step 2: Create your own policies
 
 This sample uses three types of policies: a unified sign-up/sign-in policy & a profile editing policy.  Create one policy of each type by following [the instructions here](https://azure.microsoft.com/documentation/articles/active-directory-b2c-reference-policies).  You may choose to include as many or as few identity providers as you wish.
 
-If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those.  No need to create new ones just for this sample.
+If you already have existing policies in your Azure AD B2C tenant, feel free to re-use those policies.  
 
-### [OPTIONAL] Step 4: Create your own Web API
+### Step 3: Register your own Web API
 
-This sample calls an API at https://fabrikamb2chello.azurewebsites.net which has the same code as the sample [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi). You'll need your own API or at the very least, you'll need to [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) so that you can define the scopes that your single page application will request access tokens for. 
+As you saw in the demo environment, this sample calls a Web API at https://fabrikamb2chello.azurewebsites.net which has the same code as the sample [Node.js Web API with Azure AD B2C](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi). You'll need to replace the demo environment Web API with your own Web API.
+
+If you do not have your own Web API, you can use the 
+
+you'll need to [register a Web API with Azure AD B2C](https://docs.microsoft.com/azure/active-directory-b2c/active-directory-b2c-app-registration#register-a-web-api) so that you can define the scopes that your single page application will request access tokens for. 
+
 
 Your web API registration should include the following information:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are two ways to run this sample:
 
 ## Using the demo environment
 
-This sample demostrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clicking on the **Call Web API** button shows the Display name you used when you created your account. 
+This sample demonstrates how to sign in or sign up for an account at "Wingtip Toys" - the demo environment for this sample. Once signed-in, clicking on the **Call Web API** button shows the Display name you used when you created your account. 
 
 ### Step 1: Clone or download this repository
 
@@ -45,9 +45,9 @@ Listening on port 6420...
 
 You can visit `http://localhost:6420` and click the **Login** button to start the Azure AD B2C sign in or sign up workflow.  
 
-## Using the Azure AD B2C Tenant
+## Using your own Azure AD B2C Tenant
 
-Now that you have a good idea what this sample application does, it's time to configure the sample to use your own Azure AD B2C tenant. 
+In the previous section, you learned how to run the sample application using the demo environment. In this section, you'll learn how to configure this single page application sample and the related [Node.js Web API with Azure AD B2C sample](https://github.com/Azure-Samples/active-directory-b2c-javascript-nodejs-webapi) to work with your own Azure AD B2C Tenant. 
 
 ### Step 1: Get your own Azure AD B2C tenant
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ author: jmprieur
 
 This simple sample demonstrates how to use the [Microsoft Authentication Library Preview for JavaScript (msal.js)](https://github.com/AzureAD/microsoft-authentication-library-for-js) to get an access token and call an API secured by Azure AD B2C.
 
-## How To Run This Sample
+## How to run this sample
 
 There are two ways to run this sample:
 1. **Using the demo environment** - The sample is already configured to use a demo environment and can be run simply by downloading this repository and running the app on your machine. See steps below for Running with demo environment.
@@ -34,6 +34,7 @@ From your shell or command line:
 
 ```
 cd active-directory-b2c-javascript-msal-singlepageapp
+npm install && npm update
 node server.js
 ```
 


### PR DESCRIPTION
The readme now calls out the specific steps involved to download, register, and run the Node.js Web API and how to use and register the SPA that's included in this repository. 