### PR TITLE
conditional logic fix

### DIFF
--- a/JavaScriptSPA/authConfig.js
+++ b/JavaScriptSPA/authConfig.js
@@ -1,7 +1,9 @@
 
-// Config object to be passed to Msal on creation.
-// For a full list of msal.js configuration parameters, 
-// visit https://azuread.github.io/microsoft-authentication-library-for-js/docs/msal/modules/_configuration_.html
+/**
+ * Config object to be passed to Msal on creation.
+ * For a full list of msal.js configuration parameters, 
+ * visit https://azuread.github.io/microsoft-authentication-library-for-js/docs/msal/modules/_configuration_.html
+ * */
 const msalConfig = {
   auth: {
     clientId: "e760cab2-b9a1-4c0d-86fb-ff7084abd902",
@@ -14,9 +16,10 @@ const msalConfig = {
   }
 };
 
-// Add here scopes for id token to be used at the MS Identity Platform endpoint
-// For a full list of available authentication parameters, 
-// visit https://azuread.github.io/microsoft-authentication-library-for-js/docs/msal/modules/_authenticationparameters_.html
+/** 
+ * Scopes you enter here will be consented once you authenticate. For a full list of available authentication parameters, 
+ * visit https://azuread.github.io/microsoft-authentication-library-for-js/docs/msal/modules/_authenticationparameters_.html
+ */
 const loginRequest = {
   scopes: ["openid", "profile"],
 };

--- a/JavaScriptSPA/authConfig.js
+++ b/JavaScriptSPA/authConfig.js
@@ -1,6 +1,6 @@
 
 /**
- * Config object to be passed to Msal on creation.
+ * Config object to be passed to MSAL on creation.
  * For a full list of msal.js configuration parameters, 
  * visit https://azuread.github.io/microsoft-authentication-library-for-js/docs/msal/modules/_configuration_.html
  * */

--- a/JavaScriptSPA/authPopup.js
+++ b/JavaScriptSPA/authPopup.js
@@ -5,7 +5,7 @@ const myMSALObj = new Msal.UserAgentApplication(msalConfig);
 function signIn() {
   myMSALObj.loginPopup(loginRequest)
     .then(loginResponse => {
-        console.log('id_token acquired at: ' + new Date().toString());
+        console.log("id_token acquired at: " + new Date().toString());
         console.log(loginResponse);  
         
         if (myMSALObj.getAccount()) {
@@ -26,12 +26,12 @@ function logout() {
 function getTokenPopup(request) {
   return myMSALObj.acquireTokenSilent(request)
     .catch(error => {
-      console.log("silent token acquisition fails. acquiring token using popup");
+      console.log("Silent token acquisition fails. Acquiring token using popup");
       console.log(error);
       // fallback to interaction when silent call fails
       return myMSALObj.acquireTokenPopup(request)
         .then(tokenResponse => {
-          console.log('access_token acquired at: ' + new Date().toString());
+          console.log("access_token acquired at: " + new Date().toString());
           return tokenResponse;
         }).catch(error => {
           console.log(error);
@@ -43,9 +43,9 @@ function getTokenPopup(request) {
 function passTokenToApi() {
   getTokenPopup(tokenRequest)
     .then(tokenResponse => {
-        console.log('access_token acquired at: ' + new Date().toString());
+        console.log("access_token acquired at: " + new Date().toString());
         try {
-          logMessage("Request made to Web API:")
+          logMessage("Request made to Web API:");
           callApiWithAccessToken(apiConfig.webApi, tokenResponse.accessToken);
         } catch(err) {
           console.log(err);

--- a/JavaScriptSPA/authRedirect.js
+++ b/JavaScriptSPA/authRedirect.js
@@ -12,22 +12,22 @@ function authRedirectCallBack(error, response) {
     console.log(error);
   } else {
     if (response.tokenType === "id_token") {
-      console.log('id_token acquired at: ' + new Date().toString());
+      console.log("id_token acquired at: " + new Date().toString());
       myMSALObj.getAccount();
       getTokenRedirect(tokenRequest);
     } else if (response.tokenType === "access_token") {
-        console.log('access_token acquired at: ' + new Date().toString());
+        console.log("access_token acquired at: " + new Date().toString());
         accessToken = response.accessToken;
-        logMessage("Request made to Web API:")
-        if (accessToken === null || accessToken === undefined) {
+        logMessage("Request made to Web API:");
+        if (accessToken) {
           try {
-            callApiWithAccessToken(apiConfig.webApi, accessToken)
+            callApiWithAccessToken(apiConfig.webApi, accessToken);
           } catch (err) {
             console.log(err);
           }
         }
     } else {
-        console.log("token type is: " + response.tokenType);
+        console.log("Token type is: " + response.tokenType);
     }
   }
 }
@@ -50,37 +50,37 @@ function logout() {
 
 // This function can be removed if you do not need to support IE
 function getTokenRedirect(request) {
-return myMSALObj.acquireTokenSilent(request)
-  .then((response) => {
-    if (response.accessToken) {
-      accessToken = response.accessToken
-      logMessage("Request made to Web API:")
+  return myMSALObj.acquireTokenSilent(request)
+    .then((response) => {
+      if (response.accessToken) {
+        accessToken = response.accessToken;
+        logMessage("Request made to Web API:");
 
-      if (accessToken === null || accessToken === undefined) {
-        try {
-          callApiWithAccessToken(apiConfig.webApi, accessToken)
-        } catch (err) {
-          console.log(err);
+        if (accessToken) {
+          try {
+            callApiWithAccessToken(apiConfig.webApi, accessToken);
+          } catch (err) {
+            console.log(err);
+          }
         }
       }
-    }
-  }).catch(error => {
-    console.log("silent token acquisition fails. acquiring token using redirect");
-    console.log(error);
-    // fallback to interaction when silent call fails
-    return myMSALObj.acquireTokenRedirect(request)
-  });
+    }).catch(error => {
+      console.log("Silent token acquisition fails. Acquiring token using redirect");
+      console.log(error);
+      // fallback to interaction when silent call fails
+      return myMSALObj.acquireTokenRedirect(request);
+    });
 }
 
 
 // calls the resource API with the token
 function passTokenToApi() {
-  if (accessToken === null || accessToken === undefined) {
+  if (!accessToken) {
     getTokenRedirect(tokenRequest);
   } else {
-      logMessage("Request made to Web API:")
+      logMessage("Request made to Web API:");
       try {
-        callApiWithAccessToken(apiConfig.webApi, accessToken)
+        callApiWithAccessToken(apiConfig.webApi, accessToken);
       } catch (err) {
         console.log(err);
       }


### PR DESCRIPTION
This PR corrects a mistake with conditional logic in `authRedirect.js`, where

` if (accessToken === null || accessToken === undefined)`

should have been 

` if (accessToken !== null || accessToken !== undefined)` or just ` if (accessToken)`

Nothing here should affect documentation as we do not discuss `authRedirect.js` in them @mmacy 