### PR TITLE
Use process.env.PORT if available

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const path = require('path');
 
 //initialize express.
 const app = express();
-const port = 6420; 
+const port = process.env.PORT || 6420; 
 
 // Configure morgan module to log all requests.
 app.use(morgan('dev'));


### PR DESCRIPTION
Running the sample as an Azure web app with Node requires the app to listen on a port specified by Azure Web Apps.

This requirement is likely to elude newcomers to node, so I suggest adding it by default, like the Azure AD B2C Node API demo does.